### PR TITLE
Upgrade logback to 1.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 
 ext {
-    logbackVersion = '1.1.7'
+    logbackVersion = '1.2.1'
     awsVersion = '1.11.35'
     guavaVersion = '19.0'
     jacksonVersion = '2.7.6'


### PR DESCRIPTION
Logback 1.2.0 introduces a [backwards-incompatible change to the Encoder interface](https://logback.qos.ch/news.html). This pull request upgrades the Logback dependency to version 1.2.1 and contains the changes required to support the updated Encoder interface.